### PR TITLE
Remove earn.com data source, use BCi instead

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,9 +60,9 @@ func Query() ([]byte, error) {
 	}
 
 	return json.Marshal(&responseData{
-		Priority:      feeData.Priority,
-		Normal:        feeData.Normal,
-		Economic:      feeData.Economic,
+		Priority:      superData.Limits.Max,
+		Normal:        superData.Priority,
+		Economic:      superData.Regular,
 		SuperEconomic: superData.Limits.Min,
 	})
 }


### PR DESCRIPTION
earn.com fee estimate API is now completely inaccurate.

Use BCi until we get our own Bitcoin Core full nodes hooked up.